### PR TITLE
Autoscroll fix

### DIFF
--- a/app/scroll/layout.tsx
+++ b/app/scroll/layout.tsx
@@ -1,11 +1,11 @@
 'use client';
 import { useEffect } from 'react';
 
-
 export default function Layout({ children }) {
   useEffect(() => {
     window.scrollTo(0, 0);
   }, []);
+  
   return (
     <div>
       <div

--- a/app/scroll/layout.tsx
+++ b/app/scroll/layout.tsx
@@ -1,4 +1,11 @@
+'use client';
+import { useEffect } from 'react';
+
+
 export default function Layout({ children }) {
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, []);
   return (
     <div>
       <div
@@ -13,6 +20,7 @@ export default function Layout({ children }) {
         Layout content with a height of 102vh.
       </div>
       {children}
+
     </div>
   );
 }


### PR DESCRIPTION
[Auto scroll to Page content on Link click when Layout content takes up full height of viewport #63497](https://github.com/vercel/next.js/issues/63497)

autoscroll fix